### PR TITLE
bugfix : images were not renderring

### DIFF
--- a/Helpers/imageProcessingHelpers.js
+++ b/Helpers/imageProcessingHelpers.js
@@ -140,7 +140,15 @@ const processAndSaveImage = async (imageUrl, altText, userId, req) => {
 
     // Path'i ayarla
     image.path = `/api/images/${image._id}`;
-    image.url = `${req.protocol}://${req.get("host")}${image.path}`;
+
+    // Use absolute URL based on environment
+    const isProduction = process.env.NODE_ENV === "production";
+    if (isProduction) {
+      image.url = `http://api.cassandra.com.tr${image.path}`;
+    } else {
+      image.url = `${req.protocol}://${req.get("host")}${image.path}`;
+    }
+
     await image.save();
 
     return {
@@ -228,6 +236,7 @@ const processPostImages = async (markdownContent, userId, req) => {
         );
 
         // Markdown'daki URL'yi güncelle - tam URL kullan
+        // Ensure we're using the absolute URL with domain (savedImage.url already has the full URL)
         const newMarkdown = `![${imageData.altText}](${savedImage.url})`;
         updatedContent = updatedContent.replace(
           imageData.originalMatch,

--- a/Helpers/jupyterProcessingHelpers.js
+++ b/Helpers/jupyterProcessingHelpers.js
@@ -70,7 +70,11 @@ const processJupyterFolder = async (folderPath, userId, req) => {
         image.path = `/api/images/${image._id}`;
         await image.save();
 
-        const newImageUrl = `${req.protocol}://${req.get("host")}${image.path}`;
+        // Use absolute URL based on environment
+        const isProduction = process.env.NODE_ENV === "production";
+        const newImageUrl = isProduction
+          ? `http://api.cassandra.com.tr${image.path}`
+          : `${req.protocol}://${req.get("host")}${image.path}`;
 
         // Markdown'da bu dosyanın referansını güncelle
         updatedMarkdown = updateMarkdownImageReference(

--- a/Helpers/markdownProcessingHelpers.js
+++ b/Helpers/markdownProcessingHelpers.js
@@ -134,7 +134,11 @@ const saveImageToDatabase = async (
 
     // URL'i tam olarak oluştur - req varsa full URL, yoksa relative
     if (req) {
-      image.url = `${req.protocol}://${req.get("host")}${image.path}`;
+      // Use absolute URL based on environment
+      const isProduction = process.env.NODE_ENV === "production";
+      image.url = isProduction
+        ? `http://api.cassandra.com.tr${image.path}`
+        : `${req.protocol}://${req.get("host")}${image.path}`;
     } else {
       image.url = image.path; // Fallback olarak relative path
     }

--- a/controllers/imageController.js
+++ b/controllers/imageController.js
@@ -9,8 +9,17 @@ const path = require("path");
 const os = require("os");
 
 // Yardımcı: çalışma anında tam URL oluştur
-const makeFullUrl = (req, relativePath) =>
-  `${req.protocol}://${req.get("host")}${relativePath}`;
+const makeFullUrl = (req, relativePath) => {
+  const isProduction = process.env.NODE_ENV === "production";
+
+  // In production, always use the absolute URL with the domain
+  if (isProduction) {
+    return `http://api.cassandra.com.tr${relativePath}`;
+  }
+
+  // In development, use the request's origin
+  return `${req.protocol}://${req.get("host")}${relativePath}`;
+};
 
 /**
  * Çoklu görsel yükleme


### PR DESCRIPTION
This pull request standardizes how absolute image URLs are generated across the codebase, ensuring that in production environments, all image links use the main domain (`api.cassandra.com.tr`). In development, URLs continue to be constructed dynamically from the request. This change improves consistency for image access and helps prevent broken links due to environment differences.

**Image URL standardization:**

* Updated `processAndSaveImage`, `processJupyterFolder`, and `saveImageToDatabase` functions in `Helpers/imageProcessingHelpers.js`, `Helpers/jupyterProcessingHelpers.js`, and `Helpers/markdownProcessingHelpers.js` to generate absolute image URLs based on the environment, using the production domain when appropriate. [[1]](diffhunk://#diff-136400f6bffb211ba675d9308fe9ece9af6a44726a8540224ac779fa8cfe4af1R143-R151) [[2]](diffhunk://#diff-9c882f090496849d449df0f572a90d1b450bf044be6fbd0313f6b55c353997e2L73-R77) [[3]](diffhunk://#diff-1551e7a28bc9f777f1745d879497ddccde4ebdd194bf0a53cc117a65182654dcL137-R141)
* Refactored the `makeFullUrl` helper in `controllers/imageController.js` to use the production domain for absolute URLs and fall back to the request origin in development.

**Markdown content updates:**

* Ensured that when processing post images, the markdown content is updated to use the new absolute image URLs, improving reliability of rendered images.